### PR TITLE
Feat/ping endpoint

### DIFF
--- a/backend/src/main/java/de/htw/radvis/RadvisMockBackendApplication.java
+++ b/backend/src/main/java/de/htw/radvis/RadvisMockBackendApplication.java
@@ -1,4 +1,4 @@
-package de.htw.radvis_mock_backend;
+package de.htw.radvis;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/backend/src/test/java/de/htw/radvis/RadvisMockBackendApplicationTests.java
+++ b/backend/src/test/java/de/htw/radvis/RadvisMockBackendApplicationTests.java
@@ -1,4 +1,4 @@
-package de.htw.radvis_mock_backend;
+package de.htw.radvis;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/backend/src/test/java/de/htw/radvis/ping/PingControllerTest.java
+++ b/backend/src/test/java/de/htw/radvis/ping/PingControllerTest.java
@@ -1,4 +1,0 @@
-package de.htw.radvis.ping;
-
-public class PingControllerTest {
-}

--- a/backend/src/test/java/de/htw/radvis/web/PingControllerTest.java
+++ b/backend/src/test/java/de/htw/radvis/web/PingControllerTest.java
@@ -1,0 +1,24 @@
+package de.htw.radvis.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class PingControllerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @Test
+    public void returnOkJson() throws Exception {
+        mockMvc.perform(get("/api/ping"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok").value(true));
+    }
+}


### PR DESCRIPTION
### T1.81 – Add /api/ping endpoint

**Summary**
Added a simple /api/ping endpoint to check if the backend is up and responding correctly.

**Changes**

- created PingController in de.htw.radvis.web

- implemented GET /api/ping returning `{"ok": true, "service": "mock-backend"}`
- added PingControllerTest using MockMvc to make sure the endpoint returns status 200 and the expected JSON

**Why**
This endpoint acts as a quick check for the backend and makes it easier to test the connection from the Angular frontend later on.

**Next steps**
Implement the first real feature endpoint for /api/meldungen (POST )