### PR TITLE
feat: add Report entity, Issue enum, JPA repository and initial H2 co…

### DIFF
--- a/backend/src/main/java/de/htw/radvis/data/ReportRepository.java
+++ b/backend/src/main/java/de/htw/radvis/data/ReportRepository.java
@@ -1,0 +1,7 @@
+package de.htw.radvis.data;
+
+import de.htw.radvis.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {}
+

--- a/backend/src/main/java/de/htw/radvis/domain/Issue.java
+++ b/backend/src/main/java/de/htw/radvis/domain/Issue.java
@@ -1,0 +1,9 @@
+package de.htw.radvis.domain;
+
+public enum Issue {
+    SCHLAGLOCH,
+    SCHLECHTER_STRASSENBELAG,
+    BEWUCHS,
+    FEHLENDE_BESCHILDERUNG,
+    FALSCHE_BESCHILDERUNG
+}

--- a/backend/src/main/java/de/htw/radvis/domain/Report.java
+++ b/backend/src/main/java/de/htw/radvis/domain/Report.java
@@ -1,0 +1,78 @@
+package de.htw.radvis.domain;
+
+import jakarta.persistence.*;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+@Entity
+@Table
+public class Report implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Issue issue;
+
+    @Column(length = 255)
+    private String description;
+
+    private double latitude;
+    private double longitude;
+
+    @Column(nullable = false, updatable = false)
+    private Instant creationDate = Instant.now();
+
+
+    // ----------- Getter & Setter ------------
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Issue getIssue() {
+        return issue;
+    }
+
+    public void setIssue(Issue issue) {
+        this.issue = issue;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public double getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(double latitude) {
+        this.latitude = latitude;
+    }
+
+    public double getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(double longitude) {
+        this.longitude = longitude;
+    }
+
+    public Instant getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Instant creationDate) {
+        this.creationDate = creationDate;
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:radvis;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update   # für Dev ok (erzwingt Schema-Erzeugung/-Anpassung)
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+server:
+  port: 8080


### PR DESCRIPTION
T1.82 - Add Report entity and database setup

**Summary**
Added the basic persistence layer for reports including the JPA entity, enum, repository and H2 configuration.

**Changes**
- implemented Report entity with coordinates, issue type and creation date
- added Issue enum for report categories
- created ReportRepository using Spring Data JPA
- added application.yml with H2 in-memory database and JPA setup

**Next steps**
Add DTOs and controller logic for creating new reports through the REST API.