### PR TITLE
feat: implement POST /api/reports endpoint

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -53,7 +53,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/backend/src/main/java/de/htw/radvis/app/ReportService.java
+++ b/backend/src/main/java/de/htw/radvis/app/ReportService.java
@@ -1,0 +1,30 @@
+package de.htw.radvis.app;
+
+import de.htw.radvis.data.ReportRepository;
+import de.htw.radvis.domain.Report;
+import de.htw.radvis.web.ReportCreateDTO;
+import de.htw.radvis.web.ReportResponseDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    public ReportService(ReportRepository reportRepository) {
+        this.reportRepository = reportRepository;
+    }
+
+    public ReportResponseDTO create(ReportCreateDTO dto) {
+        Report report = new Report();
+        report.setIssue(dto.getIssue());
+        report.setDescription(dto.getDescription());
+        report.setLatitude(dto.getLatitude());
+        report.setLongitude(dto.getLongitude());
+
+        var saved = reportRepository.save(report);
+        return new ReportResponseDTO(
+                saved.getId(),
+                saved.getIssue(),
+                saved.getCreationDate());
+    }
+}

--- a/backend/src/main/java/de/htw/radvis/domain/Report.java
+++ b/backend/src/main/java/de/htw/radvis/domain/Report.java
@@ -19,8 +19,8 @@ public class Report implements Serializable {
     @Column(length = 255)
     private String description;
 
-    private double latitude;
-    private double longitude;
+    private Double latitude;
+    private Double longitude;
 
     @Column(nullable = false, updatable = false)
     private Instant creationDate = Instant.now();
@@ -56,7 +56,7 @@ public class Report implements Serializable {
         return latitude;
     }
 
-    public void setLatitude(double latitude) {
+    public void setLatitude(Double latitude) {
         this.latitude = latitude;
     }
 

--- a/backend/src/main/java/de/htw/radvis/web/ReportController.java
+++ b/backend/src/main/java/de/htw/radvis/web/ReportController.java
@@ -1,0 +1,30 @@
+package de.htw.radvis.web;
+
+import de.htw.radvis.app.ReportService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.net.URI;
+
+@Controller
+@RequestMapping("/api/reports")
+@CrossOrigin(origins = "http://localhost:4200")
+public class ReportController {
+
+    private final ReportService reportService;
+    public ReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ReportResponseDTO>createReport(@Valid @RequestBody ReportCreateDTO reportCreateDTO) {
+        var response = reportService.create(reportCreateDTO);
+        var location = URI.create("/api/reports" + response.id());
+        return ResponseEntity.created(location).body(response);
+    }
+}

--- a/backend/src/main/java/de/htw/radvis/web/ReportCreateDTO.java
+++ b/backend/src/main/java/de/htw/radvis/web/ReportCreateDTO.java
@@ -1,0 +1,56 @@
+package de.htw.radvis.web;
+
+import de.htw.radvis.domain.Issue;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public class ReportCreateDTO {
+
+    @NotNull
+    private Issue issue;
+
+    @NotNull @Size(min = 1, max = 255)
+    private String description;
+
+    // latitude ∈ [-90, 90], longitude ∈ [-180, 180]
+    @DecimalMin("-90.0") @DecimalMax("90.0")
+    private Double latitude;
+    @DecimalMin("-180.0") @DecimalMax("180.0")
+    private Double longitude;
+
+    // -------- Getter and Setters ---------
+
+    public Issue getIssue() {
+        return issue;
+    }
+
+    public void setIssue(Issue issue) {
+        this.issue = issue;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public double getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(Double latitude) {
+        this.latitude = latitude;
+    }
+
+    public double getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(Double longitude) {
+        this.longitude = longitude;
+    }
+}

--- a/backend/src/main/java/de/htw/radvis/web/ReportResponseDTO.java
+++ b/backend/src/main/java/de/htw/radvis/web/ReportResponseDTO.java
@@ -1,0 +1,8 @@
+package de.htw.radvis.web;
+
+import de.htw.radvis.domain.Issue;
+
+import java.time.Instant;
+
+public record ReportResponseDTO(Long id, Issue issue, Instant created) {
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password:
   jpa:
     hibernate:
-      ddl-auto: update   # für Dev ok (erzwingt Schema-Erzeugung/-Anpassung)
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
**Summary**
Implements the first real API flow for creating reports

**Changes**
- added ReportCreateDTO for incoming report data with validation
- added ReportResponseDTO for API responses
- implemented ReportService with create() method and repository integration
- added ReportController with PostMapping to handle incoming reports
- verified end-to-end persistence with H2 in-memory database

**Why**
Completes T1.9 – POST Endpunkt and enables the frontend to submit new reports

**How to test (manual)**
```
curl -X POST http://localhost:8080/api/reports \
  -H "Content-Type: application/json" \
  -d '{"issue":"SCHLAGLOCH","description":"Großes Schlagloch am Straßenrand","latitude":52.52,"longitude":13.41}'

```

**Expected:** 201 Created, response body with id, issue, creationDate.
(See data in H2 console at /h2-console, JDBC URL jdbc:h2:mem:radvis, user sa.)

**Next steps**
- GET /api/issues (list)
- Optional validation: “either issue or description must be present”
- Error handling for nicer 400 responses