### PR TITLE
T1.10 – Implement GET /api/issues

### DIFF
--- a/backend/src/main/java/de/htw/radvis/web/IssueController.java
+++ b/backend/src/main/java/de/htw/radvis/web/IssueController.java
@@ -1,0 +1,21 @@
+package de.htw.radvis.web;
+
+import de.htw.radvis.domain.Issue;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping
+@CrossOrigin(origins = "http://localhost:4200")
+public class IssueController {
+
+    @GetMapping("/api/issues")
+    public List<Issue> getIssues() {
+        return List.of(Issue.values());
+    }
+}


### PR DESCRIPTION
**Summary**
Adds a simple GET endpoint to provide all available issue types to the frontend.
This allows the frontend to dynamically populate dropdowns or filters with the current enum values.

**Changes**
- added IssueController under de.htw.radvis.web
- implemented GET `/api/issues `returning a JSON list of all Issue enum values
- enabled CORS for `http://localhost:4200` to allow frontend access

**How to test**
**Request:**
`curl -X GET http://localhost:8080/api/issues`

`["SCHLAGLOCH", "SCHLECHTER_STRASSENBELAG", "BEWUCHS", "FEHLENDE_BESCHILDERUNG", "FALSCHE_BESCHILDERUNG"]`

<img width="1177" height="52" alt="Bildschirmfoto vom 2025-10-23 11-52-37" src="https://github.com/user-attachments/assets/883d915c-65cd-4a6c-9d12-35c6d29a5b50" />
