### PR TITLE
fix: add missing slash in Location URI for POST /api/reports response

### DIFF
--- a/backend/src/main/java/de/htw/radvis/web/ReportController.java
+++ b/backend/src/main/java/de/htw/radvis/web/ReportController.java
@@ -24,7 +24,7 @@ public class ReportController {
     @PostMapping
     public ResponseEntity<ReportResponseDTO>createReport(@Valid @RequestBody ReportCreateDTO reportCreateDTO) {
         var response = reportService.create(reportCreateDTO);
-        var location = URI.create("/api/reports" + response.id());
+        var location = URI.create("/api/reports/" + response.id());
         return ResponseEntity.created(location).body(response);
     }
 }


### PR DESCRIPTION
ensures correct URI format (/api/reports/{id}) in the response instead of /api/reports{id}