### PR TITLE
Update super-linter.yml

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -26,5 +26,6 @@ jobs:
         env:
           FIX_TYPESCRIPT_ES: true
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_TYPESCRIPT_STANDARD: false
           DEFAULT_BRANCH: "main"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The TYPESCRIPT_STANDARD linter is misconfigured and blocks PRs. We already have TYPESCRIPT_ES (ESLint) checking TypeScript code, so we can disable it.
Changes:

Added VALIDATE_TYPESCRIPT_STANDARD: false

Result:

✅ TypeScript PRs will no longer be blocked
✅ Code is still checked by ESLint