### PR TITLE
fix(formular): ensure proper FormData structure for report upload

### DIFF
--- a/frontend/src/app/formular/formular.ts
+++ b/frontend/src/app/formular/formular.ts
@@ -72,18 +72,28 @@ export class Formular implements OnInit {
       return;
     }
 
-// FormData anstatt JSON
-    const formData = new FormData();
-    formData.append('issue', this.selectedCategory ?? '');
-    formData.append('description', this.description.trim());
-    formData.append('latitude', '52.52');
-    formData.append('longitude', '13.405');
+  /// Backend erwartet ein "report"
+    const report = {
+   issue: this.selectedCategory ?? '',
+   description: this.description.trim(),
+   latitude: 52.52,
+   longitude: 13.405
+ };
 
+ // FormData mit Report und JSON
+  const formData = new FormData();
+  formData.append(
+   'report',
+   new Blob([JSON.stringify(report)], { type: 'application/json' })
+ );
+
+ // Fotos (MockBackend "photo")
     if (this.selectedFiles.length > 0) {
-      this.selectedFiles.forEach((file: File) => {
-        formData.append('photo', file);
-      });
-    }
+      this.selectedFiles.forEach(file => {
+      formData.append('photo', file);
+   });
+ }
+
 
     this.isLoading.set(true);
     console.log('Sende FormData ab...');


### PR DESCRIPTION
This PR restores the correct multipart request structure required by the MockBackend.
The endpoint /api/reports explicitly expects a report RequestPart (JSON serialized as a Blob) and optional photo files.

In the current frontend, this logic had been overwritten in a later commit, removing the required report field. As a result, the upload became incompatible with the MockBackend and produced errors such as:

MissingServletRequestPartException: Required part 'report' is not present


This PR reinstates the correct implementation inside submitReport():

Recreate the report JSON object

Serialize it as a Blob (application/json)

Append it to FormData under the key report

Append all selected photos under the key photo

Ensure the POST request matches the expected multipart structure

With these changes, the MockBackend processes the request successfully again.

What was changed

Restored the correct multipart FormData construction

Correctly append photos to the same FormData

No UI or logic changes outside of the upload process

Background

The previous working implementation was unintentionally overwritten, removing the multipart report block. This PR restores the required behavior.

Testing

Verified upload works with and without photos

Confirmed the MockBackend receives both report and photo

Hibernate inserts are logged as expected