### PR TITLE
fix: Kategorie-Auswahl korrigiert – falscher value führte zu null im Backend

### DIFF
--- a/frontend/src/app/formular/formular.html
+++ b/frontend/src/app/formular/formular.html
@@ -6,7 +6,7 @@
       <mat-label>Mängelkategorie</mat-label>
       <mat-select [(ngModel)]="selectedCategory" name="category">
         @for (cat of categories; track cat) {
-          <mat-option [value]="cat.valueOf">{{ cat }}</mat-option>
+        <mat-option [value]="cat">{{ cat }}</mat-option>
         }
       </mat-select>
     </mat-form-field>


### PR DESCRIPTION
Die Mängelkategorie wurde im Formular immer als null an das Backend gesendet,
weil im Template fälschlicherweise `cat.valueOf` verwendet wurde.
Dies übergab eine Funktion statt des Enum-Strings und Spring konnte
den Enum-Wert nicht mappen.

Die Option-Auswahl wurde korrigiert zu `[value]="cat"`, sodass nun der korrekte
Enum-Name übertragen und im Backend richtig verarbeitet wird.